### PR TITLE
Add Docker setup (PHP 7.4 + Apache + MySQL 8.0)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,19 @@
+# VTENext Docker — variabili d'ambiente
+# Copia in .env e modifica i valori
+
+APP_PORT=8080
+
+DB_ROOT_PASSWORD=root
+DB_NAME=vtenext
+DB_USER=vtenext
+DB_PASSWORD=vtenext
+DB_PORT_EXPOSED=3306
+
+# Credenziali admin VTENext (usate al primo avvio)
+VTENEXT_ADMIN_PASS=admin
+VTENEXT_ADMIN_EMAIL=admin@vtenext.local
+VTENEXT_USER_PASS=user
+VTENEXT_USER_EMAIL=user@vtenext.local
+
+# phpMyAdmin (accessibile solo con: docker compose --profile tools up)
+PMA_PORT=8081

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,100 @@
+FROM php:7.4-apache-bullseye
+
+LABEL maintainer="Castaldo Solutions <info@castaldosolutions.it>"
+LABEL description="VTENext CE - Dockerized for local development and testing"
+LABEL source="https://github.com/VTECRM/vtenext"
+
+# System dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    unzip \
+    libpng-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    libxml2-dev \
+    libzip-dev \
+    libicu-dev \
+    libc-client-dev \
+    libkrb5-dev \
+    libonig-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# PHP extensions required by VTENext
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-install -j$(nproc) \
+        curl \
+        imap \
+        xml \
+        gd \
+        bcmath \
+        mbstring \
+        zip \
+        pdo \
+        pdo_mysql \
+        mysqli \
+        intl \
+        opcache \
+        sockets
+
+# Suggested: APCu for cache
+RUN pecl install apcu && docker-php-ext-enable apcu
+
+# Apache mod_rewrite
+RUN a2enmod rewrite
+
+# Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Clone VTENext from GitHub
+ARG VTENEXT_BRANCH=main
+RUN cd / \
+    && rm -rf /var/www/html \
+    && git clone --depth=1 --branch=${VTENEXT_BRANCH} \
+    https://github.com/VTECRM/vtenext.git /var/www/html \
+    && rm -rf /var/www/html/.git
+
+# Install Composer dependencies
+WORKDIR /var/www/html
+RUN composer install --no-dev --optimize-autoloader --no-interaction
+
+# Fix: check_db_utf8_support() called as global but defined inside Installation_Utils class
+# https://github.com/VTECRM/vtenext/issues
+RUN php -r "\
+\$f = '/var/www/html/include/install/resources/utils.php'; \
+\$c = file_get_contents(\$f); \
+\$c = str_replace('check_db_utf8_support(\$conn)', 'self::check_db_utf8_support(\$conn)', \$c); \
+\$c = str_replace('function self::check_db_utf8_support', 'function check_db_utf8_support', \$c); \
+file_put_contents(\$f, \$c); \
+echo 'Patched utils.php' . PHP_EOL; \
+"
+
+# PHP configuration
+COPY php.ini /usr/local/etc/php/conf.d/vtenext.ini
+
+# Apache VirtualHost
+COPY vhost.conf /etc/apache2/sites-available/000-default.conf
+
+# Permissions
+RUN chown -R www-data:www-data /var/www/html \
+    && find /var/www/html -type d -exec chmod 755 {} \; \
+    && find /var/www/html -type f -exec chmod 644 {} \;
+
+# Writable directories required by VTENext
+RUN chmod -R 775 \
+    /var/www/html/cache \
+    /var/www/html/logs \
+    /var/www/html/upload \
+    /var/www/html/storage \
+    2>/dev/null || true
+
+EXPOSE 80
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 FROM php:7.4-apache-bullseye
 
-LABEL maintainer="Castaldo Solutions <info@castaldosolutions.it>"
 LABEL description="VTENext CE - Dockerized for local development and testing"
 LABEL source="https://github.com/VTECRM/vtenext"
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,86 @@
+# VTENext CE — Docker Setup
+
+Setup Docker per eseguire [VTENext CE](https://github.com/VTECRM/vtenext) in locale per sviluppo e testing.
+
+## Stack
+
+| Servizio | Immagine | Porta default |
+|----------|----------|---------------|
+| VTENext (PHP 8.1 + Apache) | build locale | 8080 |
+| MySQL 8.0 | `mysql:8.0` | 3306 |
+| phpMyAdmin *(opzionale)* | `phpmyadmin:latest` | 8081 |
+
+## Avvio rapido
+
+```bash
+# 1. Clona questo repo o copia la cartella docker/
+cd mcp/vtenext/docker
+
+# 2. Configura le variabili d'ambiente
+cp .env.example .env
+
+# 3. Build e avvio
+docker compose up -d --build
+
+# 4. Apri il wizard di installazione
+open http://localhost:8080
+```
+
+Durante il wizard inserisci:
+
+| Campo | Valore |
+|-------|--------|
+| DB Host | `db` |
+| DB Name | `vtenext` |
+| DB User | `vtenext` |
+| DB Password | `vtenext` |
+
+> La prima build richiede qualche minuto — deve clonare il repo GitHub e installare le dipendenze Composer.
+
+## phpMyAdmin (opzionale)
+
+```bash
+docker compose --profile tools up -d
+# Apri http://localhost:8081
+```
+
+## Comandi utili
+
+```bash
+# Logs in tempo reale
+docker compose logs -f vtenext
+
+# Shell nel container
+docker exec -it vtenext_app bash
+
+# Ricrea tutto da zero (attenzione: cancella il DB)
+docker compose down -v && docker compose up -d --build
+
+# Stop senza cancellare i dati
+docker compose stop
+```
+
+## Struttura file
+
+```
+docker/
+├── Dockerfile          # PHP 8.1 + Apache + estensioni VTENext
+├── docker-compose.yml  # Orchestrazione servizi
+├── php.ini             # Impostazioni PHP richieste da VTENext
+├── vhost.conf          # VirtualHost Apache
+├── mysql.cnf           # Configurazione MySQL (utf8mb4, native auth)
+├── entrypoint.sh       # Script di avvio (crea dir, fix permessi)
+├── .env.example        # Template variabili d'ambiente
+└── README.md           # Questo file
+```
+
+## Estensioni PHP installate
+
+`curl` · `imap` · `xml` · `gd` · `bcmath` · `mbstring` · `zip` · `pdo_mysql` · `mysqli` · `intl` · `opcache` · `apcu`
+
+## Note
+
+- Il sorgente VTENext viene clonato da `https://github.com/VTECRM/vtenext` al momento della build
+- Per usare un branch/tag specifico: `docker compose build --build-arg VTENEXT_BRANCH=<tag>`
+- I dati sono persistenti nei volumi Docker — sopravvivono ai restart
+- Per un ambiente di produzione: aggiungi HTTPS via reverse proxy (Nginx + Let's Encrypt)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,85 @@
+name: vtenext
+
+services:
+
+  vtenext:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VTENEXT_BRANCH: main
+    image: vtenext-ce
+    container_name: vtenext_app
+    restart: unless-stopped
+    ports:
+      - "${APP_PORT:-8080}:80"
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_NAME: ${DB_NAME:-vtenext}
+      DB_USER: ${DB_USER:-vtenext}
+      DB_PASSWORD: ${DB_PASSWORD:-vtenext}
+      VTENEXT_ADMIN_PASS: ${VTENEXT_ADMIN_PASS:-admin}
+      VTENEXT_ADMIN_EMAIL: ${VTENEXT_ADMIN_EMAIL:-admin@vtenext.local}
+      VTENEXT_USER_PASS: ${VTENEXT_USER_PASS:-user}
+      VTENEXT_USER_EMAIL: ${VTENEXT_USER_EMAIL:-user@vtenext.local}
+    volumes:
+      - vtenext_upload:/var/www/html/upload
+      - vtenext_storage:/var/www/html/storage
+      - vtenext_logs:/var/www/html/logs
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - appnet
+
+  db:
+    image: mysql:8.0
+    container_name: vtenext_db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${DB_NAME:-vtenext}
+      MYSQL_USER: ${DB_USER:-vtenext}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-vtenext}
+    ports:
+      - "${DB_PORT_EXPOSED:-3306}:3306"
+    volumes:
+      - vtenext_db_data:/var/lib/mysql
+      - ./mysql.cnf:/etc/mysql/conf.d/vtenext.cnf:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - appnet
+
+  pma:
+    image: phpmyadmin:latest
+    container_name: vtenext_pma
+    restart: unless-stopped
+    ports:
+      - "${PMA_PORT:-8081}:80"
+    environment:
+      PMA_HOST: db
+      PMA_USER: ${DB_USER:-vtenext}
+      PMA_PASSWORD: ${DB_PASSWORD:-vtenext}
+      UPLOAD_LIMIT: 128M
+    depends_on:
+      - db
+    networks:
+      - appnet
+    profiles:
+      - tools
+
+volumes:
+  vtenext_db_data:
+  vtenext_upload:
+  vtenext_storage:
+  vtenext_logs:
+
+networks:
+  appnet:
+    driver: bridge

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# Ensure writable directories exist
+mkdir -p /var/www/html/cache \
+         /var/www/html/logs \
+         /var/www/html/upload \
+         /var/www/html/storage
+
+chown -R www-data:www-data \
+    /var/www/html/cache \
+    /var/www/html/logs \
+    /var/www/html/upload \
+    /var/www/html/storage
+
+chmod -R 775 \
+    /var/www/html/cache \
+    /var/www/html/logs \
+    /var/www/html/upload \
+    /var/www/html/storage
+
+# Copy .htaccess if not present
+if [ -f /var/www/html/.htaccess.txt ] && [ ! -f /var/www/html/.htaccess ]; then
+    cp /var/www/html/.htaccess.txt /var/www/html/.htaccess
+fi
+
+# Write config.db.php from environment variables if still contains placeholders
+if grep -q '_DBC_TYPE_' /var/www/html/config.db.php 2>/dev/null; then
+    echo "Writing config.db.php from environment variables..."
+    cat > /var/www/html/config.db.php << EOF
+<?php
+  \$dbconfig['db_server']   = '${DB_HOST:-db}';
+  \$dbconfig['db_port']     = '${DB_PORT:-3306}';
+  \$dbconfig['db_sockpath'] = '';
+  \$dbconfig['db_username'] = '${DB_USER:-vtenext}';
+  \$dbconfig['db_password'] = '${DB_PASSWORD:-vtenext}';
+  \$dbconfig['db_name']     = '${DB_NAME:-vtenext}';
+  \$dbconfig['db_type']     = 'mysql';
+  \$dbconfig['db_bundled']  = 'false';
+  \$vtconfig['adminPwd']            = '${VTENEXT_ADMIN_PASS:-admin}';
+  \$vtconfig['standarduserPwd']     = '${VTENEXT_USER_PASS:-user}';
+  \$vtconfig['adminEmail']          = '${VTENEXT_ADMIN_EMAIL:-admin@vtenext.local}';
+  \$vtconfig['standarduserEmail']   = '${VTENEXT_USER_EMAIL:-user@vtenext.local}';
+  \$vtconfig['demoData']            = 'false';
+  \$vtconfig['currencyName']        = 'Euro(\xe2\x82\xac)';
+  \$vtconfig['quickbuild']          = 'false';
+EOF
+    chown www-data:www-data /var/www/html/config.db.php
+fi
+
+exec "$@"

--- a/docker/mysql.cnf
+++ b/docker/mysql.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+default-authentication-plugin = mysql_native_password
+sql_mode = NO_ENGINE_SUBSTITUTION
+max_allowed_packet = 32M
+innodb_buffer_pool_size = 256M

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,25 @@
+; VTENext required PHP settings
+
+[PHP]
+short_open_tag = On
+output_buffering = On
+display_errors = On
+log_errors = On
+file_uploads = On
+max_execution_time = 600
+memory_limit = 128M
+post_max_size = 32M
+upload_max_filesize = 32M
+max_input_vars = 10000
+
+error_reporting = E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT
+
+[Date]
+date.timezone = Europe/Rome
+
+[opcache]
+opcache.enable = 1
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 8
+opcache.max_accelerated_files = 4000
+opcache.revalidate_freq = 60

--- a/docker/vhost.conf
+++ b/docker/vhost.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+
+    <Directory /var/www/html>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/vtenext_error.log
+    CustomLog ${APACHE_LOG_DIR}/vtenext_access.log combined
+</VirtualHost>


### PR DESCRIPTION
## Summary

This PR adds a self-contained Docker setup to run VTENext CE locally for development and testing, with no manual PHP or MySQL configuration required.

- PHP 7.4 + Apache (Debian Bullseye) + MySQL 8.0
- phpMyAdmin included (optional, via `--profile tools`)
- All required PHP extensions pre-installed: `curl`, `imap`, `gd`, `bcmath`, `mbstring`, `zip`, `pdo_mysql`, `mysqli`, `intl`, `opcache`, `apcu`, `sockets`
- Data persistence via named Docker volumes

## Bug fixes included

Two bugs in the installation wizard are patched automatically:

1. **`utils.php` line 138** — `check_db_utf8_support()` is called as a global function but is defined as a static method inside `Installation_Utils`. Fixed by replacing with `self::check_db_utf8_support()` at build time.

2. **`config.db.php`** — the wizard does not always write the DB config, leaving `_DBC_TYPE_` placeholders. The entrypoint script writes this file from environment variables at container startup.

## Usage

```bash
cp docker/.env.example docker/.env
docker compose -f docker/docker-compose.yml up -d --build
```

Open **http://localhost:8080/install.php** and follow the wizard.

## Test plan

- [x] Built and tested on Docker Desktop (Windows)
- [x] Full installation wizard completed successfully
- [x] 331 tables created in MySQL
- [x] Admin login working after installation
- [x] Published on Docker Hub: https://hub.docker.com/r/gaetano88/vtenext-ce